### PR TITLE
fix: update totalSpend on User entity after committing payment

### DIFF
--- a/src/main/java/com/paymentteamproject/domain/user/entity/User.java
+++ b/src/main/java/com/paymentteamproject/domain/user/entity/User.java
@@ -88,11 +88,6 @@ public class User extends BaseEntity {
     }
 
     public void updateTotalSpend(BigDecimal amount){
-        // NPE 방지
-        if (this.totalSpend == null) {
-            this.totalSpend = BigDecimal.ZERO;
-        }
-
         this.totalSpend = this.totalSpend.add(amount);
     }
 

--- a/src/main/java/com/paymentteamproject/domain/user/service/UserEventListener.java
+++ b/src/main/java/com/paymentteamproject/domain/user/service/UserEventListener.java
@@ -1,0 +1,37 @@
+package com.paymentteamproject.domain.user.service;
+
+import com.paymentteamproject.domain.payment.event.TotalSpendChangedEvent;
+import com.paymentteamproject.domain.user.entity.User;
+import com.paymentteamproject.domain.user.exception.UserNotFoundException;
+import com.paymentteamproject.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component // 더 가벼움
+@RequiredArgsConstructor
+public class UserEventListener {
+    private final UserRepository userRepository;
+
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Async
+    public void handleTotalSpendChangedEvent(TotalSpendChangedEvent event){
+        log.info("이벤트 수신: 사용자ID = {}, 추가 금액 = {}", event.user().getId(), event.newSpend());
+
+        User foundUser = userRepository.findById(event.user().getId())
+                .orElseThrow(UserNotFoundException::new);
+
+        foundUser.updateTotalSpend(event.newSpend());
+
+        // 명시적으로 DB에 즉시 반영 명령
+        userRepository.saveAndFlush(foundUser);
+
+        log.info("업데이트 완료: 총 결제액 = {}", foundUser.getTotalSpend());
+    }
+}

--- a/src/main/java/com/paymentteamproject/domain/user/service/UserService.java
+++ b/src/main/java/com/paymentteamproject/domain/user/service/UserService.java
@@ -73,18 +73,6 @@ public class UserService {
                 .build();
     }
 
-    @EventListener
-    @Transactional
-    @Async
-    public void handleTotalSpendChangedEvent(TotalSpendChangedEvent event){
-        User user = event.user();
-
-        User foundUser = userRepository.findById(user.getId())
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
-
-        foundUser.updateTotalSpend(event.newSpend());
-    }
-
 }
 
 


### PR DESCRIPTION
## 📝 작업 내용
- userService에 있던 이벤트리스너를 별도의 컴포넌트로 분리
- @Transactional(propagation = Propagation.REQUIRES_NEW) 설정을 이용하여 결제 성공 후 비동기로 데이터 업데이트 가능하도록 수정

## 🔗 관련 이슈 (Related Issues)
Closes #

## ✅ 체크리스트 (Checklist)
- [x] 코딩 컨벤션을 준수했나요?
- [x] 메서드/클래스 네이밍이 적절한가요?
- [x] 기능에 대한 테스트 코드를 작성/수행했나요?
- [x] 포스트맨/프론트엔드를 통한 API 동작을 확인했나요?
- [x] 불필요한 주석이나 로그(console.log)를 제거했나요?

## 💬 기타 사항